### PR TITLE
Dont wait for whole CVS file to get parsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-import-react",
-  "version": "1.0.11",
+  "version": "1.1.00",
   "description": "Open-source CSV and XLS/XLSX file importer for React and JavaScript",
   "main": "build/index.js",
   "module": "build/index.esm.js",

--- a/src/importer/features/main/index.tsx
+++ b/src/importer/features/main/index.tsx
@@ -25,6 +25,7 @@ export default function Main(props: CSVImporterProps) {
     modalOnCloseTriggered = () => null,
     template,
     onComplete,
+    onCSVHeadersMapped,
     customStyles,
     showDownloadTemplateButton,
     skipHeaderRowSelection,
@@ -196,6 +197,13 @@ export default function Main(props: CSVImporterProps) {
             onSuccess={(columnMapping) => {
               setIsSubmitting(true);
               setColumnMapping(columnMapping);
+              if (onCSVHeadersMapped) {
+                onCSVHeadersMapped(columnMapping).then(() => {
+                  setIsSubmitting(false);
+                  goNext();
+                });
+                return;
+              }
 
               // TODO (client-sdk): Move this type, add other data attributes (i.e. column definitions), and move the data processing to a function
               type MappedRow = {


### PR DESCRIPTION
**Why this change is needed?**
- In case of very large files, waiting time for parsing to finish is considerably long.
- Instead, just complete the CSV headers to key mapping and return the mapping. This will fasten the process and reduce the waiting time
- Also, `Import Successful` message is displayed too early and this wording will confuse user in thinking that the actual CSV file has been mapped, parsed and uploaded/imported. So we need some mechanism where we display `Import Successful` message only after the data is really "imported" and not just parsed.


**Proposed changes**

- Addition of `onCSVHeadersMapped?: (data: any) => Promise<void>;` to `CSVImporterProps`
- Addition of below logic in [`case StepEnum.MapColumns:` success callback](https://github.com/tableflowhq/csv-import/blob/main/src/importer/features/main/index.tsx#L196)
```
      case StepEnum.MapColumns:
        return (
          <MapColumns
            template={parsedTemplate}
            data={data}
            columnMapping={columnMapping}
            skipHeaderRowSelection={skipHeader}
            selectedHeaderRow={selectedHeaderRow}
            onSuccess={(columnMapping) => {
              setIsSubmitting(true);
              setColumnMapping(columnMapping);
              if (onCSVHeadersMapped) {
                onCSVHeadersMapped(columnMapping).then(() => {
                  setIsSubmitting(false);
                  goNext();
                });
                return;
              }
```