### PR TITLE
allow skipping upload if file is provided

### DIFF
--- a/src/components/CSVImporter/CSVImporter.stories.tsx
+++ b/src/components/CSVImporter/CSVImporter.stories.tsx
@@ -52,7 +52,18 @@ const Template: Story<typeof ImporterComponent> = (args: CSVImporterProps) => {
 
   return (
     <div>
-      {args.isModal && <button onClick={() => setIsOpen(true)}>Import</button>}
+      {args.isModal && (
+        <>
+          <button onClick={() => setIsOpen(true)}>Import</button>
+          <input
+            type="file"
+            onChange={(e) => {
+              args.file = e.target.files?.[0];
+              setIsOpen(true);
+            }}
+          />
+        </>
+      )}
       <ImporterComponent key={props.isModal?.toString()} {...props} />
     </div>
   );

--- a/src/importer/components/UploaderWrapper/UploaderWrapper.tsx
+++ b/src/importer/components/UploaderWrapper/UploaderWrapper.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { UploaderWrapperProps } from "./types";
 import { useDropzone } from "react-dropzone";
-import { Box, Text } from "@chakra-ui/react";
 import { Button } from "@chakra-ui/button";
-import { PiArrowCounterClockwise, PiFile } from "react-icons/pi";
+import { Box, Text } from "@chakra-ui/react";
 import useThemeStore from "../../stores/theme";
+import { UploaderWrapperProps } from "./types";
+import { PiArrowCounterClockwise, PiFile } from "react-icons/pi";
 
 export default function UploaderWrapper({ onSuccess, setDataError, ...props }: UploaderWrapperProps) {
   const [loading, setLoading] = useState(false);
@@ -34,24 +34,19 @@ export default function UploaderWrapper({ onSuccess, setDataError, ...props }: U
   });
 
   return (
-    <Box
-      padding="15px"
-      border="1px solid var(--color-border)"
-      borderRadius="var(--border-radius-2)"
-    >
-      <Box 
-        {...getRootProps()} 
-        width="100%" 
+    <Box padding="15px" border="1px solid var(--color-border)" borderRadius="var(--border-radius-2)">
+      <Box
+        {...getRootProps()}
+        width="100%"
         height="100%"
-        display="flex" 
-        justifyContent="center" 
-        alignItems="center" 
-        flexDirection="column" 
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        flexDirection="column"
         flex={1}
         border="2px dashed var(--color-border)"
-        borderRadius="var(--border-radius-2)"
-      >
-        <input {...getInputProps()}/>
+        borderRadius="var(--border-radius-2)">
+        <input {...getInputProps()} />
         {isDragActive ? (
           <Text>Drop your file here</Text>
         ) : loading ? (
@@ -60,17 +55,20 @@ export default function UploaderWrapper({ onSuccess, setDataError, ...props }: U
           <>
             <Text>Drop your file here</Text>
             <Text>or</Text>
-            <Button 
-              leftIcon={<PiFile />} 
-              onClick={open} 
-              mt="6px" 
-              colorScheme={"secondary"} 
+            <Button
+              leftIcon={<PiFile />}
+              onClick={open}
+              mt="6px"
+              colorScheme={"secondary"}
               variant={theme === "light" ? "outline" : "solid"}
-              _hover={theme === "light" ? {
-                background: "var(--color-border)",
-                color: "var(--color-text)"
-              } : undefined}
-            >
+              _hover={
+                theme === "light"
+                  ? {
+                      background: "var(--color-border)",
+                      color: "var(--color-text)",
+                    }
+                  : undefined
+              }>
               Browse files
             </Button>
           </>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,4 +17,5 @@ export type CSVImporterProps = (HTMLAttributes<HTMLDialogElement> & HTMLAttribut
   customStyles?: Record<string, string> | string;
   showDownloadTemplateButton?: boolean;
   skipHeaderRowSelection?: boolean;
+  file?: File;
 } & ModalParams;


### PR DESCRIPTION
This PR adds a new `file` argument to the main component. If passed in, it will skip the upload screen and immediately process the passed in file.

This will allow devs to implement their own file selection process, potentially allowing for multiple files and schemas uploaded at once, in sequence