### PR TITLE
Add support for multi-column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ template={{
       name: "Age",
       data_type: "number",
     },
+    {
+      name: "Category",
+      // `multiple` allows multiple source columns to be mapped to a single destination column
+      multiple: true,
+      // `combiner` is the function used to combine the values from multiple source columns; defaults to joining with a space
+      combiner: (values: string[]) => values.join(' | '),
+    }
   ],
 }}
 ```
@@ -233,7 +240,7 @@ Toggle between dark mode (`true`) and light mode (`false`).
 Specifies the primary color for the importer in hex format. Use `customStyles` to customize the UI in more detail.
 
 ```jsx
-primaryColor="#7A5EF8"
+primaryColor = "#7A5EF8";
 ```
 
 ### customStyles (_object_)
@@ -271,6 +278,7 @@ customStyles={{
 ## Internationalization
 
 ### Predefined languages
+
 - Out-of-the-box support for various languages.
 - Common languages are available through the language prop (i.e., `language="fr"` for French).
 - Available predefined languages:
@@ -279,6 +287,7 @@ customStyles={{
   - fr
 
 ### Customizable language
+
 - Language keys can be exported and overridden.
 - Labels and messages can be customized to any text.
 - Translations key examples can be found in `src/i18n/es.ts`
@@ -317,31 +326,36 @@ When set to `true`, the importer will not display and skip the Header Row Select
 To set up the project locally, follow these steps:
 
 1. **Clone the repository**
+
 ```bash
 git clone https://github.com/tableflowhq/csv-import.git
 cd csv-import
 ```
 
 2. **Install dependencies**
+
 ```bash
 yarn install
 ```
 
 3. **Build the project**
+
 ```bash
 yarn build
 ```
 
 ### Running Storybook
+
 To run Storybook locally, follow these steps:
 
 1. **Start Storybook**
+
 ```bash
 yarn storybook
 ```
 
 2. **Open Storybook in your browser:**
-Storybook should automatically open in your default browser. If it doesn't, navigate to [http://localhost:6006](http://localhost:6006).
+   Storybook should automatically open in your default browser. If it doesn't, navigate to [http://localhost:6006](http://localhost:6006).
 
 ### Modifying the project and testing with the demo app
 

--- a/package-js.json
+++ b/package-js.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-import-js",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Open-source CSV, TSV, and XLS/XLSX file importer for React and JavaScript",
   "main": "index.js",
   "files": ["."],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-import-react",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Open-source CSV, TSV, and XLS/XLSX file importer for React and JavaScript",
   "main": "build/index.js",
   "module": "build/index.esm.js",

--- a/src/components/CSVImporter/CSVImporter.stories.tsx
+++ b/src/components/CSVImporter/CSVImporter.stories.tsx
@@ -35,6 +35,11 @@ const template = {
       required: true,
       description: "The email of the user",
     },
+    {
+      name: "Category",
+      multiple: true,
+      combiner: (values: string[]) => values.join(" | "),
+    },
   ],
 };
 

--- a/src/importer/components/Input/index.tsx
+++ b/src/importer/components/Input/index.tsx
@@ -123,6 +123,7 @@ function Select({ options = {}, placeholder, ...props }: InputProps) {
                 onClick={onChangeOption}
                 autoFocus={i === 0}>
                 {k} {options[k].required && <span className={style.requiredMark}>*</span>}
+                {options[k].multiple && <span className={style.multipleMark}>Multiple</span>}
               </button>
             ))}
           </div>

--- a/src/importer/components/Input/style/Input.module.scss
+++ b/src/importer/components/Input/style/Input.module.scss
@@ -223,11 +223,11 @@
     }
     .multipleMark {
       color: var(--color-text-soft);
-      font-size: 0.75em;
+      font-size: var(--font-size-s);
       background-color: var(--color-background-menu-hover);
-      padding: 1px 4px;
+      padding: var(--m-xxxxs) var(--m-xxxs);
       border-radius: var(--border-radius-1);
-      margin-left: 4px;
+      margin-left: var(--m-xxxs);
     }
   }
 }

--- a/src/importer/components/Input/style/Input.module.scss
+++ b/src/importer/components/Input/style/Input.module.scss
@@ -221,6 +221,14 @@
     .requiredMark {
       color: var(--color-text-error);
     }
+    .multipleMark {
+      color: var(--color-text-soft);
+      font-size: 0.75em;
+      background-color: var(--color-background-menu-hover);
+      padding: 1px 4px;
+      border-radius: var(--border-radius-1);
+      margin-left: 4px;
+    }
   }
 }
 

--- a/src/importer/components/Input/types/index.ts
+++ b/src/importer/components/Input/types/index.ts
@@ -16,7 +16,7 @@ export type inputTypes =
   | "week";
 
 export type InputVariants = "fluid" | "small";
-export type InputOption = ButtonHTMLAttributes<HTMLButtonElement> & { required?: boolean };
+export type InputOption = ButtonHTMLAttributes<HTMLButtonElement> & { required?: boolean; multiple?: boolean };
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement> &
   InputHTMLAttributes<HTMLSelectElement> &

--- a/src/importer/features/map-columns/components/DropDownFields.tsx
+++ b/src/importer/features/map-columns/components/DropDownFields.tsx
@@ -43,7 +43,8 @@ export default function DropdownFields({ options, value, placeholder, onChange, 
     for (const key in options) {
       const option = options[key];
       const isSelected = selectedValues.some((item) => item.key === option?.value && item.selected && option.value !== value);
-      if (!isSelected) {
+      // Allow multiple selections for columns with multiple: true
+      if (!isSelected || option?.multiple) {
         newFilteredOptions[key] = option;
       }
     }

--- a/src/importer/features/map-columns/types/index.ts
+++ b/src/importer/features/map-columns/types/index.ts
@@ -5,6 +5,7 @@ export type TemplateColumnMapping = {
   key: string;
   include: boolean;
   selected?: boolean;
+  isMultiple?: boolean;
 };
 
 export type MapColumnsProps = {

--- a/src/importer/types/index.ts
+++ b/src/importer/types/index.ts
@@ -8,6 +8,8 @@ export type TemplateColumn = {
   description?: string;
   required?: boolean;
   suggested_mappings?: string[];
+  multiple?: boolean;
+  combiner?: (values: string[]) => string;
 };
 
 export type UploadColumn = {

--- a/src/importer/utils/template.ts
+++ b/src/importer/utils/template.ts
@@ -32,6 +32,8 @@ export function convertRawTemplate(rawTemplate?: Record<string, unknown> | strin
     const description: string = item.description || "";
     const required: boolean = item.required || false;
     let suggestedMappings: string[] = item.suggested_mappings || [];
+    const multiple: boolean = item.multiple || false;
+    const combiner = item.combiner;
 
     if (name === "") {
       return [null, `Invalid template: The parameter "name" is required for each column (check column ${i})`];
@@ -41,6 +43,10 @@ export function convertRawTemplate(rawTemplate?: Record<string, unknown> | strin
     }
     if (seenKeys[key]) {
       return [null, `Invalid template: Duplicate keys are not allowed (check column ${i})`];
+    }
+    
+    if (combiner && typeof combiner !== "function") {
+      return [null, `Invalid template: The parameter "combiner" must be a function (check column ${i})`];
     }
 
     seenKeys[key] = true;
@@ -63,6 +69,8 @@ export function convertRawTemplate(rawTemplate?: Record<string, unknown> | strin
       description,
       required,
       suggested_mappings: suggestedMappings,
+      multiple,
+      combiner,
     } as TemplateColumn);
   }
 


### PR DESCRIPTION
Adds support for mapping multiple source columns to a single destination column. Adds two new configuration properties:
* `multiple (boolean)` - determines whether or not the destination column can be mapped from multiple source columns; defaults to `false`
* `combiner (function)` - the function used to combine the values from multiple source columns; defaults to joining strings with a space in between

<img width="1409" height="966" alt="image" src="https://github.com/user-attachments/assets/3ba88c26-3849-4673-8902-1fb5e11c697f" />
